### PR TITLE
Add key export feature

### DIFF
--- a/contracts/wallet/DelayedFinalizationBool.sol
+++ b/contracts/wallet/DelayedFinalizationBool.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title DelayedFinalizationBool
+ * @notice Provides functions for managing bools with a delayed finalization
+ * mechanism. Bool updates always refer to changes in assignment.
+ */
+library DelayedFinalizationBool {
+    struct BoolStatus {
+        // Current value
+        bool _bool;
+        // Block number when pending bool was set
+        uint256 pendingBlockNumber;
+    }
+
+    /**
+     * @notice Sets a new bool as pending.
+     * @param boolStatus Bool status in storage
+     * @param newBool The new bool to set
+     */
+    function updateBool(BoolStatus storage boolStatus, bool newBool) internal {
+        require(boolStatus.pendingBlockNumber < block.number, "Bool: Multiple changes in the same block");
+        boolStatus._bool = newBool;
+        boolStatus.pendingBlockNumber = block.number;
+    }
+
+    /**
+     * @notice Gets the finalized bool for a given key. Reverts if the bool is still pending finalization.
+     * @param boolStatus Bool status in storage
+     * @return The finalized bool
+     */
+    function getFinalizedBool(BoolStatus storage boolStatus) internal view returns (bool) {
+        require(boolStatus.pendingBlockNumber < block.number, "Bool is pending finalization");
+        return boolStatus._bool;
+    }
+
+    /**
+     * @notice Checks if an bool is finalized for a given key without returning the bool.
+     *         Useful for access control checks.
+     * @param boolStatus Bool status in storage
+     * @param comparisonBool The bool to check
+     * @return True if the bool is finalized for the key, false otherwise
+     */
+    function isFinalizedBool(BoolStatus storage boolStatus, bool comparisonBool) internal view returns (bool) {
+        if (boolStatus.pendingBlockNumber >= block.number) {
+            // Pending finalization, don't reveal
+            return false;
+        }
+        return boolStatus._bool == comparisonBool;
+    }
+}

--- a/contracts/wallet/MinimalUpgradableWalletReceiver.sol
+++ b/contracts/wallet/MinimalUpgradableWalletReceiver.sol
@@ -9,7 +9,7 @@ contract MinimalUpgradableWalletReceiver {
         (pk, sk) = Sapphire.generateCurve25519KeyPair(new bytes(0));
     }
 
-    function decryptKeyFromRequest(
+    function decrypt(
         bytes memory ciphertext,
         bytes32 nonce,
         Sapphire.Curve25519PublicKey peerPublicKey,
@@ -19,14 +19,13 @@ contract MinimalUpgradableWalletReceiver {
         decrypted = Sapphire.decrypt(sharedKey, nonce, ciphertext, new bytes(0));
     }
 
-    function encryptPrivateKey(
-        bytes memory _privateKey,
+    function encrypt(
+        bytes memory message,
+        Sapphire.Curve25519SecretKey secretKey,
         Sapphire.Curve25519PublicKey curve25519PublicKey
-    ) public view returns (bytes memory ciphertext, bytes32 nonce, Sapphire.Curve25519PublicKey mySharedPubKey) {
-        Sapphire.Curve25519SecretKey sk;
-        (mySharedPubKey, sk) = Sapphire.generateCurve25519KeyPair(new bytes(0));
-        bytes32 sharedKey = Sapphire.deriveSymmetricKey(curve25519PublicKey, sk);
+    ) public view returns (bytes memory ciphertext, bytes32 nonce) {
+        bytes32 sharedKey = Sapphire.deriveSymmetricKey(curve25519PublicKey, secretKey);
         nonce = bytes32(Sapphire.randomBytes(32, new bytes(0)));
-        ciphertext = Sapphire.encrypt(sharedKey, nonce, _privateKey, new bytes(0));
+        ciphertext = Sapphire.encrypt(sharedKey, nonce, message, new bytes(0));
     }
 }

--- a/scripts/minimal-upgradable-wallet/recipient-3-decrypt-key.ts
+++ b/scripts/minimal-upgradable-wallet/recipient-3-decrypt-key.ts
@@ -53,7 +53,7 @@ async function main() {
     }
   }
 
-  let decryptedKey = await reciever.decryptKeyFromRequest(
+  let decryptedKey = await reciever.decrypt(
     keyData.ciphertext,
     keyData.nonce,
     keyData.sharedPubKey,

--- a/test/minimal-upgradable-wallet.ts
+++ b/test/minimal-upgradable-wallet.ts
@@ -1,6 +1,8 @@
 import { ethers } from "hardhat";
 import { Contract, Signer, type ContractFactory } from "ethers";
 import { expect } from "chai";
+import { MinimalUpgradableWallet } from "../typechain-types/contracts/wallet/MinimalUpgradableWallet";
+import { MinimalUpgradableWalletReceiver } from "../typechain-types/contracts/wallet/MinimalUpgradableWalletReceiver";
 
 function retryPromise<T>(factory: () => Promise<T>, timeout: number = 60000): Promise<T> {
   let tries = 0;
@@ -30,7 +32,7 @@ function retryPromise<T>(factory: () => Promise<T>, timeout: number = 60000): Pr
   });
 }
 
-async function getMinimalUpgradableWalletReceiver() {
+async function getMinimalUpgradableWalletReceiver(): Promise<MinimalUpgradableWalletReceiver> {
   const receiverFactory = await ethers.getContractFactory("MinimalUpgradableWalletReceiver");
   console.log("Deploying MinimalUpgradableWalletReceiver...");
   const receiver = await retryPromise(() => receiverFactory.deploy());
@@ -39,45 +41,36 @@ async function getMinimalUpgradableWalletReceiver() {
 }
 
 describe("MinimalUpgradableWalletReceiver", function () {
-  let MinimalUpgradableWalletReceiver: Awaited<
-    ReturnType<typeof getMinimalUpgradableWalletReceiver>
-  >;
+  let minimalUpgradableWalletReceiver: MinimalUpgradableWalletReceiver;
   let senderSk: string, senderPk: string, receiverSk: string, receiverPk: string;
   let owner: Signer;
 
   async function initialDeployments() {
     // Deploy the contract before each test
     [owner] = await ethers.getSigners();
-    MinimalUpgradableWalletReceiver = await getMinimalUpgradableWalletReceiver();
+    minimalUpgradableWalletReceiver = await getMinimalUpgradableWalletReceiver();
 
     // Generate key pairs for sender and receiver
     console.log("Generating keypairs...");
-    ({ pk: senderPk, sk: senderSk } = await MinimalUpgradableWalletReceiver.generateKeyPair());
-    ({ pk: receiverPk, sk: receiverSk } = await MinimalUpgradableWalletReceiver.generateKeyPair());
+    ({ pk: senderPk, sk: senderSk } = await minimalUpgradableWalletReceiver.generateKeyPair());
+    ({ pk: receiverPk, sk: receiverSk } = await minimalUpgradableWalletReceiver.generateKeyPair());
     console.log("Keypairs generated.");
   }
-
-  it("encrypts a private key", async function () {
-    await initialDeployments();
-
-    // Encrypt a message using encryptPrivateKey
-    const privateKey = Buffer.from("This is my private key", "utf-8");
-
-    let [ciphertext, nonce, mySharedPubKey] =
-      await MinimalUpgradableWalletReceiver.encryptPrivateKey(privateKey, receiverSk);
-  });
 
   it("sends a private key in encrypted form to a receiver which decrypts it", async function () {
     await initialDeployments();
 
     // Encrypt & decrypt a message
     const privateKey = Buffer.from("This is my private key", "utf-8");
-    let [ciphertext, nonce, mySharedPubKey] =
-      await MinimalUpgradableWalletReceiver.encryptPrivateKey(privateKey, receiverPk);
-    let decryptedKey = await MinimalUpgradableWalletReceiver.decryptKeyFromRequest(
+    let [ciphertext, nonce] = await minimalUpgradableWalletReceiver.encrypt(
+      privateKey,
+      senderSk,
+      receiverPk,
+    );
+    let decryptedKey = await minimalUpgradableWalletReceiver.decrypt(
       ciphertext,
       nonce,
-      mySharedPubKey,
+      senderPk,
       receiverSk,
     );
     expect(decryptedKey).to.be.a("string");
@@ -88,28 +81,28 @@ describe("MinimalUpgradableWalletReceiver", function () {
 });
 
 describe("MinimalUpgradableWallet", function () {
-  let MinimalUpgradableWallet: any;
-  let MinimalUpgradableWalletReceiver: any;
+  let minimalUpgradableWallet: MinimalUpgradableWallet;
+  let minimalUpgradableWalletReceiver: MinimalUpgradableWalletReceiver;
   let receiverSk: string, receiverPk: string;
   let owner: Signer;
 
   async function initialDeployments() {
     // Deploy contracts before each test
     [owner] = await ethers.getSigners();
-    MinimalUpgradableWalletReceiver = await getMinimalUpgradableWalletReceiver();
+    minimalUpgradableWalletReceiver = await getMinimalUpgradableWalletReceiver();
 
     // Generate key pairs for the receiver
-    ({ pk: receiverPk, sk: receiverSk } = await MinimalUpgradableWalletReceiver.generateKeyPair());
+    ({ pk: receiverPk, sk: receiverSk } = await minimalUpgradableWalletReceiver.generateKeyPair());
 
     // Deploy the wallet
     const walletFactory = await ethers.getContractFactory("MinimalUpgradableWallet");
-    MinimalUpgradableWallet = await walletFactory.deploy(3);
+    minimalUpgradableWallet = await walletFactory.deploy(3);
   }
 
   it("sends the private key in encrypted form to a receiver which decrypts it", async function () {
     await initialDeployments();
     // Encrypt & decrypt a message
-    await MinimalUpgradableWallet.requestEncryption(receiverPk);
+    await minimalUpgradableWallet.requestEncryption(receiverPk);
     // Wait 3 blocks
     const initialBlockNumber = await ethers.provider.getBlockNumber();
     for (let i = 0; i < 3; i++) {
@@ -118,8 +111,8 @@ describe("MinimalUpgradableWallet", function () {
     const finalBlockNumber = await ethers.provider.getBlockNumber();
     expect(finalBlockNumber - initialBlockNumber).to.be.at.least(3);
 
-    let [ciphertext, nonce, mySharedPubKey] = await MinimalUpgradableWallet.encryptKeyForRequest(0);
-    let decryptedKey = await MinimalUpgradableWalletReceiver.decryptKeyFromRequest(
+    let [ciphertext, nonce, mySharedPubKey] = await minimalUpgradableWallet.encryptKeyForRequest(0);
+    let decryptedKey = await minimalUpgradableWalletReceiver.decrypt(
       ciphertext,
       nonce,
       mySharedPubKey,
@@ -128,7 +121,7 @@ describe("MinimalUpgradableWallet", function () {
     console.log("Decrypted key:", decryptedKey);
 
     // Get wallet public address
-    const walletAddress = await MinimalUpgradableWallet.ethAddress();
+    const walletAddress = await minimalUpgradableWallet.ethAddress();
     console.log("Public address of encumbered account:", walletAddress);
 
     const recoveredWallet = new ethers.Wallet(decryptedKey);


### PR DESCRIPTION
Allows export of keys (to another encumbered account or to leak it to the owner) after all encumbrance policies associated with the account have expired.